### PR TITLE
Require Node >= 10 (drop support for 8.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-          - run: yarn install
+            - run: yarn install
   lint:
     executor:
       name: node/default
@@ -20,7 +20,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-          - run: yarn lint
+            - run: yarn lint
   unit_tests:
     executor:
       name: node/default
@@ -29,14 +29,14 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-          - run:
-              name: yarn test
-              command: yarn test:coverage --ci --color --reporters=default --reporters=jest-junit --runInBand
-              environment:
-                JEST_JUNIT_OUTPUT_DIR: ./tmp/test-results
-                JEST_JUNIT_OUTPUT_NAME: jest.xml
-          - store_test_results:
-              path: ./tmp/test-results
+            - run:
+                name: yarn test
+                command: yarn test:coverage --ci --color --reporters=default --reporters=jest-junit --runInBand
+                environment:
+                  JEST_JUNIT_OUTPUT_DIR: ./tmp/test-results
+                  JEST_JUNIT_OUTPUT_NAME: jest.xml
+            - store_test_results:
+                path: ./tmp/test-results
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   install_deps:
     executor:
       name: node/default
-      tag: "8"
+      tag: "10"
     steps:
       - checkout
       - node/with-cache:
@@ -15,7 +15,7 @@ jobs:
   lint:
     executor:
       name: node/default
-      tag: "8"
+      tag: "10"
     steps:
       - checkout
       - node/with-cache:
@@ -24,7 +24,7 @@ jobs:
   unit_tests:
     executor:
       name: node/default
-      tag: "8"
+      tag: "10"
     steps:
       - checkout
       - node/with-cache:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Refer to the GitHub projects for each of these templates for more information.
 
 ## Usage
 
-To get started, make sure you have Node 8.10+ and Yarn installed, then run:
+To get started, make sure you have Node 10+ and Yarn installed, then run:
 
 ```
 $ npx spraygun --help

--- a/bin/spraygun
+++ b/bin/spraygun
@@ -5,11 +5,11 @@
 var nodeVersion = process.versions.node;
 var segments = nodeVersion.split(".");
 
-if (segments[0] < 8 || (segments[0] === "8" && segments[1] < 10)) {
+if (segments[0] < 10) {
   console.log(
     "Error: You are running Node " +
       nodeVersion +
-      ". Spraygun requires Node 8.10 or later."
+      ". Spraygun requires Node 10 or later."
   );
   process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prettier": "^1.13.7"
   },
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">=10"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
Node 8.x has reached EOL and many of our dependencies are dropping their support.

Fixes #48 