### PR TITLE
Document the npm release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,24 @@ Each template defines the app-generation process by providing a special `.sprayg
 - Displaying quick-start documentation
 
 Spraygun is heavily inspired by other Carbon Five app generators: [Raygun](https://github.com/carbonfive/raygun) (Rails) and [Razor](https://github.com/carbonfive/razor) (Phoenix).
+
+## Releasing
+
+When spraygun is installed via npm or yarn, or run via `npx`, it is downloaded from the central npm repository. New versions of spraygun are published to npm so that they are available to users.
+
+Maintainers of spraygun follow these steps to publish a new version:
+
+1. [Create an npm account](https://www.npmjs.com/signup) if you don't have one already.
+2. Enable "Authorization and Publishing" 2FA for your npm account.
+3. Ask an existing spraygun maintainer to [add your npm account as a maintainer](https://www.npmjs.com/package/spraygun/access) for the spraygun package.
+4. Clone this repo and pull the latest `master` branch.
+5. Increment the version in `package.json` according to [semver conventions](https://semver.org).
+6. Commit the change (e.g. `git commit -m "Releasing v0.4.0"`).
+7. Tag the commit using an annotated tag (e.g. `git tag -a v0.4.0 -m v0.4.0`).
+8. Push the commit and tag: `git push && git push --tags`.
+9. Make sure you are logged into the npm CLI: `npm login`.
+10. Publish to npm: `npm publish` (see troubleshooting note below).
+11. [Navigate to the tag you just pushed](https://github.com/carbonfive/spraygun/tags) and in the "..." menu, choose "Draft a new release".
+12. Name the release the same as the tag without the `v` (e.g. "0.4.0"), add release notes, and publish.
+
+Note: if you get a permissions error during `npm publish`, it might be because you were recently added as a maintainer and that hasn't fully taken effect yet. In that case an existing maintainer needs to perform the publish in order to force npm to update its permissions.


### PR DESCRIPTION
Publishing a spraygun release is a pretty lengthy process and it is not currently scripted at all. This PR documents the process that we just followed to release v0.3.0.