### PR TITLE
Upgrade CircleCI config to use node orb v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   lint:
     executor:
       name: node/default
-      tag: "10"
+      tag: "10.22"
     steps:
       - checkout
       - node/install-packages:
@@ -16,7 +16,7 @@ jobs:
   unit_tests:
     executor:
       name: node/default
-      tag: "10"
+      tag: "10.22"
     steps:
       - checkout
       - node/install-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,51 +1,37 @@
 version: 2.1
+
 orbs:
-  node: circleci/node@1.1.6
+  node: circleci/node@4
 
 jobs:
-  install_deps:
-    executor:
-      name: node/default
-      tag: "10"
-    steps:
-      - checkout
-      - node/with-cache:
-          steps:
-            - run: yarn install
   lint:
     executor:
       name: node/default
       tag: "10"
     steps:
       - checkout
-      - node/with-cache:
-          steps:
-            - run: yarn lint
+      - node/install-packages:
+          pkg-manager: yarn
+      - run: yarn lint
   unit_tests:
     executor:
       name: node/default
       tag: "10"
     steps:
       - checkout
-      - node/with-cache:
-          steps:
-            - run:
-                name: yarn test
-                command: yarn test:coverage --ci --color --reporters=default --reporters=jest-junit --runInBand
-                environment:
-                  JEST_JUNIT_OUTPUT_DIR: ./tmp/test-results
-                  JEST_JUNIT_OUTPUT_NAME: jest.xml
-            - store_test_results:
-                path: ./tmp/test-results
+      - node/install-packages:
+          pkg-manager: yarn
+      - run:
+          name: yarn test
+          command: yarn test:coverage --ci --color --reporters=default --reporters=jest-junit --runInBand
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./tmp/test-results
+            JEST_JUNIT_OUTPUT_NAME: jest.xml
+      - store_test_results:
+          path: ./tmp/test-results
 
 workflows:
-  version: 2
   build:
     jobs:
-      - install_deps
-      - lint:
-          requires:
-            - install_deps
-      - unit_tests:
-          requires:
-            - install_deps
+      - lint
+      - unit_tests


### PR DESCRIPTION
According to the example provided by CircleCI, the way to install and cache packages via yarn is to use this new command:

```
- node/install-packages:
    pkg-manager: yarn
```

https://github.com/CircleCI-Public/node-orb/blob/v4.1.0/src/examples/run_tests_with_yarn.yml

The orb will automatically cache and restore the `node_modules` directory between builds.

That means that a separate `install_deps` job is not really necessary. It solves for a race condition where two jobs running in parallel both have a dirty `node_modules` cache and both have to install new versions of dependencies. In practice, though, dependencies are not changed all that often, so the extra `install_deps` prerequisite job only slows down the common scenario where the cache does not need to change.

Note that behind the scenes the `node/default` executor is now using the new `cimg/node` docker image.

https://github.com/CircleCI-Public/cimg-node