### PR TITLE
Suggest react-ts as the default project in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Usage: spraygun <template> <project-directory>
 
 Generate a project in the specified directory, based on a template.
 
-For example, to generate a react app in a directory named hello-world:
-  $ npx spraygun -t react hello-world
+For example, to generate a React TypeScript app in a directory named blog:
+  $ npx spraygun -t react-ts blog
 
 The officially supported spraygun templates are:
   -t express

--- a/src/cli.js
+++ b/src/cli.js
@@ -25,8 +25,8 @@ const usage = chalk`${logo}
 
   Generate a project in the specified directory, based on a template.
 
-  For example, to generate a react app in a directory named hello-world:
-    {gray $} npx spraygun {yellow -t react} {green hello-world}
+  For example, to generate a React TypeScript app in a directory named blog:
+    {gray $} npx spraygun {yellow -t react-ts} {green blog}
 
   The officially supported spraygun templates are:
 ${aliasBullets}

--- a/src/resolvers/template.test.js
+++ b/src/resolvers/template.test.js
@@ -10,11 +10,11 @@ describe("resolve", () => {
       const repositoryResolve = require("./repository");
       repositoryResolve.mockReturnValue("/path/to/resolved/repo");
 
-      const path = resolve("react");
+      const path = resolve("react-ts");
 
       expect(path).toEqual("/path/to/resolved/repo");
       expect(repositoryResolve).toHaveBeenCalledWith(
-        "https://github.com/carbonfive/spraygun-react.git"
+        "https://github.com/carbonfive/spraygun-react-ts.git"
       );
     });
   });


### PR DESCRIPTION
We are moving toward TypeScript as our default language of choice for React. Update spraygun to recommend `react-ts`.