### PR TITLE
Remove react (JS) from list of built-in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Spraygun is a JavaScript application generator that builds projects with Carbon 
 Three application templates are supported out of the box:
 
 - [spraygun-express](https://github.com/carbonfive/spraygun-express)
-- [spraygun-react](https://github.com/carbonfive/spraygun-react)
 - [spraygun-react-ts](https://github.com/carbonfive/spraygun-react-ts)
 
 Refer to the GitHub projects for each of these templates for more information.
@@ -32,7 +31,6 @@ For example, to generate a React TypeScript app in a directory named blog:
 
 The officially supported spraygun templates are:
   -t express
-  -t react
   -t react-ts
 
 To use a custom template, specify one of the following:

--- a/src/resolvers/template.js
+++ b/src/resolvers/template.js
@@ -2,7 +2,6 @@ const resolveRepository = require("./repository");
 
 const aliases = {
   express: "https://github.com/carbonfive/spraygun-express.git",
-  react: "https://github.com/carbonfive/spraygun-react.git",
   "react-ts": "https://github.com/carbonfive/spraygun-react-ts.git",
 };
 

--- a/src/resolvers/template.test.js
+++ b/src/resolvers/template.test.js
@@ -28,6 +28,6 @@ describe("resolve", () => {
 
 describe("aliases", () => {
   it("exports an array of alias names", () => {
-    expect(resolve.aliases).toEqual(["express", "react", "react-ts"]);
+    expect(resolve.aliases).toEqual(["express", "react-ts"]);
   });
 });


### PR DESCRIPTION
We have archived the spraygun-react repo in favor of the TypeScript version: https://github.com/carbonfive/spraygun-react-ts